### PR TITLE
Ansible: Added additional execution of cron.py for publising

### DIFF
--- a/scripts/ansible/asm_install.yml
+++ b/scripts/ansible/asm_install.yml
@@ -62,7 +62,7 @@
         - "{{ asm_data }}/cache"
         - "{{ asm_data }}/media"
         - "/srv/backups/asm"
-        - "/var/log/cron/asm"
+        - "/var/log/cron"
 
     - name: "Install release"
       command: "rsync -rlv /usr/local/src/{{ asm_archive.name }}/ {{ asm_path }}/"

--- a/scripts/ansible/templates/cron.sh
+++ b/scripts/ansible/templates/cron.sh
@@ -24,6 +24,7 @@ num_days_to_keep=5
 # ASM configured cron activies
 #----------------------------------------------------------
 /usr/bin/python $ASM_PATH/src/cron.py daily &> /var/log/cron/asm
+/usr/bin/python $ASM_PATH/src/cron.py publish_3pty &>> /var/log/cron/asm
 
 #----------------------------------------------------------
 # Backups


### PR DESCRIPTION
The cron that Ansible installs now executes cron.py multiple times.  We log all the output of the cron jobs to a single log file.  That way, we can add Zabbix monitoring to make sure the cron is executing as expected.

Fixes #435 