### PR TITLE
Fix bug in cron and recursive bug in db

### DIFF
--- a/src/cron.py
+++ b/src/cron.py
@@ -431,7 +431,7 @@ def run(dbo, mode):
 
 def run_all_map_databases(mode):
     for alias in MULTIPLE_DATABASES_MAP.iterkeys():
-        dbo = db.get_multiple_database_info(alias)
+        dbo = db.get_database(alias)
         dbo.timeout = 0
         dbo.connection = dbo.connect()
         run(dbo, mode)

--- a/src/db.py
+++ b/src/db.py
@@ -40,7 +40,7 @@ def _get_multiple_database_info(alias):
         dbo.database = "FAIL"
         return dbo
     mapinfo = MULTIPLE_DATABASES_MAP[alias]
-    dbo = get_database(mapinfo["dbtype"])
+    dbo = get_dbo(mapinfo["dbtype"])
     dbo.alias = alias
     dbo.dbtype = mapinfo["dbtype"]
     dbo.host = mapinfo["host"]


### PR DESCRIPTION
Found a bug when using multiple databases:
 - cron was using the internal function and can now use get_database()
 - db get_database() was calling the internal function, which was calling get_database() instead of get_dbo(), resulting in a recursive loop