### PR TITLE
Added support for french microchip

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,6 +1,6 @@
 43
 ================
-
+17/12/19 Add support for french microship ID #707
 16/12/19 Movement date cannot be before intake date #651
 16/12/19 Show pickup/dropoff on person links #706
 12/12/19 Lint fixes to onlineform and bad required pattern

--- a/changelog
+++ b/changelog
@@ -1,6 +1,6 @@
 43
 ================
-17/12/19 Add support for french microship ID #707
+17/12/19 Added support for french microship ID #707
 16/12/19 Movement date cannot be before intake date #651
 16/12/19 Show pickup/dropoff on person links #706
 12/12/19 Lint fixes to onlineform and bad required pattern

--- a/src/asm3/lookups.py
+++ b/src/asm3/lookups.py
@@ -151,7 +151,8 @@ MICROCHIP_MANUFACTURERS = [
     { "length": 15, "regex": r"^9910010", "name": "AKC Reunite", "locales": "en" },
     { "length": 15, "regex": r"^9910039", "name": "911PetChip", "locales": "en" },
     { "length": 15, "regex": r"^992", "name": "International Pet Registry", "locales": "" },
-    { "length": 15, "regex": r"^999", "name": "Transponder Test", "locales": ""}
+    { "length": 15, "regex": r"^999", "name": "Transponder Test", "locales": ""},
+    { "length": 15, "regex": r"^250", "name": "I-CAD", "locales": ""},
 ]
 
 VISUAL_THEMES = [


### PR DESCRIPTION
## Issue description
French Microship Manufacturer is currently not supported by ASM : 
![image](https://user-images.githubusercontent.com/8756421/71004109-ee8a6880-20e1-11ea-83ef-6a88eb5779ba.png)

[Template](https://www.i-cad.fr/articles/moyens_identification) is the following _(15 figures)_:
- 3 first figures are for the country code (250 for France, can be used as a manufacturer ID ?)
- 2 figures for the species (26 for cats and dog)
- 2 figures for the manufacturer ID
- 8 figures for the identification number, specific to the animal

## Issue resolution
- I added a additional field to `MICROCHIP_MANUFACTURERS` in [lookups.py](https://github.com/julian-poidevin/asm3/blob/b0d8de754d93f6cc27add59825a57f5d2e808f5e/src/asm3/lookups.py) file to match the "I-CAD" microchip template.
- I updated the changelog

After the change, the microchip is properly detected : 
![image](https://user-images.githubusercontent.com/8756421/71007024-93a74000-20e6-11ea-9771-d53ca5f3981a.png)

## Comments
This is my first PR, please be gentle if I made any mistakes 😄 