### PR TITLE
Removed python3-sqlite dependency

### DIFF
--- a/install/deb/makedeb.sh
+++ b/install/deb/makedeb.sh
@@ -61,7 +61,7 @@ Section: contrib
 Priority: optional
 Architecture: all
 Essential: no
-Depends: debconf, memcached, libapache2-mod-wsgi-py3, python3-webpy, python3-pil, python3-memcache, python3-requests, python3-mysqldb, python3-psycopg2, python3-sqlite
+Depends: debconf, memcached, libapache2-mod-wsgi-py3, python3-webpy, python3-pil, python3-memcache, python3-requests, python3-mysqldb, python3-psycopg2
 Suggests: mysql-server, imagemagick, wkhtmltopdf
 Installed-Size: `du -s -k sheltermanager3 | awk '{print$1}'`
 Maintainer: ASM Team [info@sheltermanager.com]


### PR DESCRIPTION
`python3-sqlite` is now part of `python3 `standard library and no longer needed as a dependency.

Please see Animal Shelter Manager 3 forum post called _"ASM3 package install failing because of python3-sqlite dependancy"_ for more details.