### PR TITLE
Removed seconds from some time wordkeys when not relevant

### DIFF
--- a/src/asm3/i18n.py
+++ b/src/asm3/i18n.py
@@ -6,8 +6,8 @@ import time
 # flake8: noqa - we have a lot of locales and this is convenient
 from asm3.locales import *
 
-VERSION = "44u [Wed 29 Apr 14:19:43 BST 2020]"
-BUILD = "04291419"
+VERSION = "44u [Thu Apr 30 00:45:15 CEST 2020]"
+BUILD = "04300045"
 
 DMY = ( "%d/%m/%Y", "%d/%m/%y" )
 HDMY = ( "%d-%m-%Y", "%d-%m-%y" )
@@ -357,6 +357,13 @@ def format_currency_no_symbol(locale, value):
 def format_time(d):
     if d is None: return ""
     return time.strftime("%H:%M:%S", d.timetuple())
+
+def format_time_custom(timeformat,d):
+    if d is None: return ""
+    try:
+        return time.strftime(timeformat, d.timetuple())
+    except:
+        return ""
 
 def format_time_now(offset = 0.0):
     return format_time(now(offset))

--- a/src/asm3/wordprocessor.py
+++ b/src/asm3/wordprocessor.py
@@ -172,7 +172,7 @@ def animal_tags(dbo, a, includeAdditional=True, includeCosts=True, includeDiet=T
         "ANIMALCREATEDBY"       : a["CREATEDBY"],
         "ANIMALCREATEDDATE"     : python2display(l, a["CREATEDDATE"]),
         "DATEBROUGHTIN"         : python2display(l, a["DATEBROUGHTIN"]),
-        "TIMEBROUGHTIN"         : format_time_custom("%H:%M",a["DATEBROUGHTIN"]),
+        "TIMEBROUGHTIN"         : format_time(a["DATEBROUGHTIN"]),
         "DATEOFBIRTH"           : python2display(l, a["DATEOFBIRTH"]),
         "AGEGROUP"              : a["AGEGROUP"],
         "DISPLAYDOB"            : displaydob,

--- a/src/asm3/wordprocessor.py
+++ b/src/asm3/wordprocessor.py
@@ -18,7 +18,7 @@ import asm3.template
 import asm3.users
 import asm3.utils
 import asm3.waitinglist
-from asm3.i18n import _, format_currency, format_currency_no_symbol, format_time, now, python2display, yes_no
+from asm3.i18n import _, format_currency, format_currency_no_symbol, format_time, format_time_custom, now, python2display, yes_no
 
 import zipfile
 
@@ -172,7 +172,7 @@ def animal_tags(dbo, a, includeAdditional=True, includeCosts=True, includeDiet=T
         "ANIMALCREATEDBY"       : a["CREATEDBY"],
         "ANIMALCREATEDDATE"     : python2display(l, a["CREATEDDATE"]),
         "DATEBROUGHTIN"         : python2display(l, a["DATEBROUGHTIN"]),
-        "TIMEBROUGHTIN"         : format_time(a["DATEBROUGHTIN"]),
+        "TIMEBROUGHTIN"         : format_time_custom("%H:%M",a["DATEBROUGHTIN"]),
         "DATEOFBIRTH"           : python2display(l, a["DATEOFBIRTH"]),
         "AGEGROUP"              : a["AGEGROUP"],
         "DISPLAYDOB"            : displaydob,
@@ -1077,14 +1077,14 @@ def clinic_tags(dbo, c):
         "ID":                   asm3.utils.padleft(c.ID, 6),
         "APPOINTMENTFOR"        : asm3.users.get_real_name(dbo, c.APPTFOR),
         "APPOINTMENTDATE"       : python2display(l, c.DATETIME),
-        "APPOINTMENTTIME"       : format_time(c.DATETIME),
+        "APPOINTMENTTIME"       : format_time_custom("%H:%M",c.DATETIME),
         "STATUS"                : c.CLINICSTATUSNAME,
         "ARRIVEDDATE"           : python2display(l, c.ARRIVEDDATETIME),
-        "ARRIVEDTIME"           : format_time(c.ARRIVEDDATETIME),
+        "ARRIVEDTIME"           : format_time_custom("%H:%M",c.ARRIVEDDATETIME),
         "WITHVETDATE"           : python2display(l, c.WITHVETDATETIME),
-        "WITHVETTIME"           : format_time(c.WITHVETDATETIME),
+        "WITHVETTIME"           : format_time_custom("%H:%M",c.WITHVETDATETIME),
         "COMPLETEDDATE"         : python2display(l, c.COMPLETEDDATETIME),
-        "COMPLETEDTIME"         : format_time(c.COMPLETEDDATETIME),
+        "COMPLETEDTIME"         : format_time_custom("%H:%M",c.COMPLETEDDATETIME),
         "REASONFORAPPOINTMENT"  : c.REASONFORAPPOINTMENT,
         "APPOINTMENTCOMMENTS"   : c.COMMENTS,
         "INVOICEAMOUNT"         : format_currency_no_symbol(l, c.AMOUNT),


### PR DESCRIPTION
For some time related wordkeys, seconds are not relevant, here's a proposed change for the **clinic** wordkeys.

I don't know how much of an impact it could have for all ASM users so I'll understand if you don't accept this PR. Plus I'm not an experienced python/javascript developer so it may be wrong.