### PR TITLE
Ansible: bug fix for python3

### DIFF
--- a/scripts/ansible/templates/cron.sh
+++ b/scripts/ansible/templates/cron.sh
@@ -23,8 +23,8 @@ num_days_to_keep=5
 #----------------------------------------------------------
 # ASM configured cron activies
 #----------------------------------------------------------
-ASM3_CONF=$ASM_DATA/asm3.conf python $ASM_PATH/src/cron.py daily &> /var/log/cron/asm
-ASM3_CONF=$ASM_DATA/asm3.conf python $ASM_PATH/src/cron.py publish_3pty &>> /var/log/cron/asm
+ASM3_CONF=$ASM_DATA/asm3.conf python3 $ASM_PATH/src/cron.py daily &> /var/log/cron/asm
+ASM3_CONF=$ASM_DATA/asm3.conf python3 $ASM_PATH/src/cron.py publish_3pty &>> /var/log/cron/asm
 
 #----------------------------------------------------------
 # Backups


### PR DESCRIPTION
The cron script deployed by Ansible was still attempting to use python 2.  I've updated the command to use python3.

Updates #855