### PR TITLE
Add RescheduleDays to TestType lookup

### DIFF
--- a/src/asm3/dbupdate.py
+++ b/src/asm3/dbupdate.py
@@ -1527,6 +1527,7 @@ def sql_structure(dbo):
         fstr("TestName"),
         fstr("TestDescription", True),
         fint("DefaultCost", True),
+        fint("RescheduleDays", True),
         fint("IsRetired", True) ), False)
 
     sql += table("testresult", (

--- a/src/asm3/lookups.py
+++ b/src/asm3/lookups.py
@@ -17,7 +17,7 @@ import re
 #   pubspec - has a PetFinderSpecies column (species)
 #   pubbreed - has a PetFinderBreed column (breed)
 #   pubcol - has an AdoptAPetColour column (basecolour)
-#   sched - has a RescheduleDays column (vaccinationtype)
+#   sched - has a RescheduleDays column (testtype, vaccinationtype)
 #   cost - has a DefaultCost column (citationtype, costtype, donationtype, licencetype)
 #   units - has Units column (internallocation)
 #   site - has SiteID column (internallocation)
@@ -59,7 +59,7 @@ LOOKUP_TABLES = {
     "stocklocation":    (_("Stock Locations"), "LocationName", _("Location"), "LocationDescription", "add del ret", ("stocklevel.StockLocationID",)),
     "stockusagetype":   (_("Stock Usage Type"), "UsageTypeName", _("Usage Type"), "UsageTypeDescription", "add del ret", ("stockusage.StockUsageTypeID",)),
     "lkurgency":        (_("Urgencies"), "Urgency", _("Urgency"), "", "", ("animalwaitinglist.Urgency",)),
-    "testtype":         (_("Test Types"), "TestName", _("Type"), "TestDescription", "add del ret cost", ("animaltest.TestTypeID",)),
+    "testtype":         (_("Test Types"), "TestName", _("Type"), "TestDescription", "add del ret cost sched", ("animaltest.TestTypeID",)),
     "testresult":       (_("Test Results"), "ResultName", _("Result"), "ResultDescription", "add del ret", ("animaltest.TestResultID",)),
     "lkstransportstatus": (_("Transport Statuses"), "Name", _("Status"), "", "", ("animaltransport.Status",)),
     "transporttype":    (_("Transport Types"), "TransportTypeName", _("Type"), "TransportTypeDescription", "add del ret", ("animaltransport.TransportTypeID",)),
@@ -1061,7 +1061,7 @@ def insert_lookup(dbo, username, lookup, name, desc="", speciesid=0, pfbreed="",
         # Create a matching account if we have a donation type
         if asm3.configuration.create_donation_trx(dbo): asm3.financial.insert_account_from_donationtype(dbo, nid, name, desc)
         return nid
-    elif lookup == "testtype" or lookup == "voucher" or lookup == "traptype" or lookup == "licencetype" or lookup == "citationtype":
+    elif lookup == "voucher" or lookup == "traptype" or lookup == "licencetype" or lookup == "citationtype":
         nid = dbo.insert(lookup, {
             t[LOOKUP_NAMEFIELD]:    name,
             t[LOOKUP_DESCFIELD]:    desc,
@@ -1069,7 +1069,7 @@ def insert_lookup(dbo, username, lookup, name, desc="", speciesid=0, pfbreed="",
             "IsRetired":            retired
         }, username, setCreated=False)
         return nid
-    elif lookup == "vaccinationtype":
+    elif lookup == "testtype" or lookup == "vaccinationtype":
         nid = dbo.insert(lookup, {
             t[LOOKUP_NAMEFIELD]:    name,
             t[LOOKUP_DESCFIELD]:    desc,
@@ -1137,7 +1137,7 @@ def update_lookup(dbo, username, iid, lookup, name, desc="", speciesid=0, pfbree
             "IsVAT":                vat,
             "IsRetired":            retired
         }, username, setLastChanged=False)
-    elif lookup == "costtype" or lookup == "testtype" or lookup == "voucher" \
+    elif lookup == "costtype" or lookup == "voucher" \
         or lookup == "traptype" or lookup == "licencetype" or lookup == "citationtype":
         dbo.update(lookup, iid, {
             t[LOOKUP_NAMEFIELD]:    name,
@@ -1145,7 +1145,7 @@ def update_lookup(dbo, username, iid, lookup, name, desc="", speciesid=0, pfbree
             "DefaultCost":          defaultcost,
             "IsRetired":            retired
         }, username, setLastChanged=False)
-    elif lookup == "vaccinationtype":
+    elif lookup == "testtype" or lookup == "vaccinationtype":
         dbo.update(lookup, iid, {
             t[LOOKUP_NAMEFIELD]:    name,
             t[LOOKUP_DESCFIELD]:    desc,

--- a/src/asm3/medical.py
+++ b/src/asm3/medical.py
@@ -712,6 +712,24 @@ def complete_test(dbo, username, testid, newdate, testresult, vetid = 0):
     }, username)
     update_animal_tests(dbo, testid)
 
+def reschedule_test(dbo, username, testid, newdate, comments):
+    """
+    Reschedules a test for a new date, copying data from the existing one.
+    Comments are appended on the existing test.
+    """
+    av = dbo.first_row(dbo.query("SELECT * FROM animaltest WHERE ID = ?", [testid]))
+    if av.COMMENTS != "": comments = "%s\n%s" % (av.COMMENTS, comments)
+    dbo.update("animaltest", testid, { "Comments": comments }, username)
+    dbo.insert("animaltest", {
+        "AnimalID":             av.ANIMALID,
+        "TestTypeID":           av.TESTTYPEID,
+        "TestResultID":         0,
+        "DateOfTest":           None,
+        "DateRequired":         newdate,
+        "Comments":             "",
+        "Cost":                 av.COST
+    }, username)
+
 def reschedule_vaccination(dbo, username, vaccinationid, newdate, comments):
     """
     Reschedules a vaccination for a new date by copying it.

--- a/src/code.py
+++ b/src/code.py
@@ -5929,10 +5929,14 @@ class test(JSONEndpoint):
     def post_perform(self, o):
         self.check(asm3.users.CHANGE_TEST)
         newdate = o.post.date("newdate")
+        retestdate = o.post.date("retest")
+        reschedulecomments = o.post["usagecomments"]
         vet = o.post.integer("givenvet")
         testresult = o.post.integer("testresult")
         for vid in o.post.integer_list("ids"):
             asm3.medical.complete_test(o.dbo, o.user, vid, newdate, testresult, vet)
+            if retestdate is not None:
+                asm3.medical.reschedule_test(o.dbo, o.user, vid, retestdate, reschedulecomments)
         if o.post.integer("item") != -1:
             asm3.stock.deduct_stocklevel_from_form(o.dbo, o.user, o.post)
 


### PR DESCRIPTION
This is a straight-forward clone of the vaccination flow. closes #921

@bobintetley one thing I didn't do (yet) is pre-filling the "Retest" field when creating a new test. I thought about adding a `onchange` handler to the type drop-down that would update the retest date. Would this be useful? Right now, a re-test would be just added when you "perform" a test.