### PR TITLE
Added Re-Index button to online forms

### DIFF
--- a/src/asm3/onlineform.py
+++ b/src/asm3/onlineform.py
@@ -576,6 +576,16 @@ def delete_onlineform(dbo, username, formid):
     dbo.execute("DELETE FROM onlineformfield WHERE OnlineFormID = ?", [formid])
     dbo.delete("onlineform", formid, username)
 
+def reindex_onlineform(dbo, username, formid):
+    """
+    Resets display indexes to space out by 10 using current order
+    """
+    fields = get_onlineformfields(dbo, formid)
+    
+    for i in range(len(fields)):
+        newindex = (i + 1) * 10
+        dbo.execute("UPDATE onlineformfield SET DISPLAYINDEX = ? WHERE OnlineFormID = ? AND ID = ?", [newindex, formid, fields[i]["ID"]])
+
 def clone_onlineform(dbo, username, formid):
     """
     Clones formid

--- a/src/code.py
+++ b/src/code.py
@@ -4515,6 +4515,9 @@ class onlineform(JSONEndpoint):
         for did in o.post.integer_list("ids"):
             asm3.onlineform.delete_onlineformfield(o.dbo, o.user, did)
 
+    def post_reindex(self, o):
+        asm3.onlineform.reindex_onlineform(o.dbo, o.user, o.post.integer("formid"))
+        
 class onlineforms(JSONEndpoint):
     url = "onlineforms"
     get_permissions = asm3.users.VIEW_ONLINE_FORMS

--- a/src/static/js/common_tableform.js
+++ b/src/static/js/common_tableform.js
@@ -1596,6 +1596,47 @@ const tableform = {
     },
 
     /**
+     * Prompts the user to re-index form
+     * callback: Function to be run if the user clicks delete
+     * text: The delete dialog text (don't pass for the default)
+     * returns a promise.
+     */
+    reindex_dialog: function(callback, text) {
+        var b = {},
+            deferred = $.Deferred();
+        b[_("Re-Index")] = function() {
+            $("#dialog-reindex").dialog("close");
+            if (callback) { callback(); }
+            deferred.resolve();
+        };
+        b[_("Cancel")] = function() {
+            $(this).dialog("close");
+            deferred.reject("dialog cancelled");
+        };
+        var mess = _("This will reset the display indexes on the form to be offset by 10");
+        if (text && text != "") {
+            mess = text;
+        }
+        if ($("#dialog-reindex").length == 0) {
+            $("body").append('<div id="dialog-reindex" style="display: none" title="' +
+                _("Re-Index") + '"><p><span class="ui-icon ui-icon-alert"></span>' +
+                '<span id="dialog-reindex-text"></span></p></div>');
+        }
+        $("#dialog-reindex-text").html(mess);
+        $("#dialog-reindex").dialog({
+            resizable: false,
+            height: "auto",
+            width: 400,
+            modal: true,
+            dialogClass: "dialogshadow",
+            show: dlgfx.reindex_show,
+            hide: dlgfx.reindex_hide,
+            buttons: b
+        });
+        return deferred.promise();
+    },
+
+    /**
      * Shows an Ok/Cancel dialog.
      * selector: The dialog div
      * oktext: The text to show on the ok button

--- a/src/static/js/onlineform.js
+++ b/src/static/js/onlineform.js
@@ -106,6 +106,15 @@ $(function() {
                         }
                     } 
                 },
+                { id: "reindex", text: _("Re-Index"), icon: "refresh", enabled: "always", perm: "eof",
+                    click: async function() {
+                        await tableform.reindex_dialog();
+                        tableform.buttons_default_state(buttons);
+                        let ids = tableform.table_ids(table);
+                        await common.ajax_post("onlineform", "mode=reindex&formid=" + controller.formid);
+                        location.reload();
+                    }
+                },
                 { id: "delete", text: _("Delete"), icon: "delete", enabled: "multi", perm: "eof", 
                     click: async function() { 
                         await tableform.delete_dialog();


### PR DESCRIPTION
Been running into major re-factors of forms lately. Some had been setup with space in between indexes but even those get filled over time.

All this does is add a button when you are viewing the form editor that resets all the indexes (in respect to their current order) by starting at 10 and adding 10 for each field.

Example random display indexes
![image](https://user-images.githubusercontent.com/1868836/117900938-e95a2a80-b28f-11eb-98dd-03376a6396e6.png)

Dialog
![image](https://user-images.githubusercontent.com/1868836/117900977-fd059100-b28f-11eb-895b-6afa59c3791f.png)

After reload forced by js
![image](https://user-images.githubusercontent.com/1868836/117901018-18709c00-b290-11eb-89f1-4f57f83b5c32.png)

