### PR TITLE
Validate that Yes or No is selected in mandatory Yes/No type form field

### DIFF
--- a/src/asm3/onlineform.py
+++ b/src/asm3/onlineform.py
@@ -179,9 +179,9 @@ def get_onlineform_html(dbo, formid, completedocument = True):
             h.append('</td>')
             h.append('<td class="asm-onlineform-td">')
         if f.FIELDTYPE == FIELDTYPE_YESNO:
-            h.append('<select class="asm-onlineform-yesno" id="%s" name="%s" title="%s">' \
+            h.append('<select class="asm-onlineform-yesno" id="%s" name="%s" data-required="%s" title="%s">' \
                 '<option value=""></option><option>%s</option><option>%s</option></select>' % \
-                ( fid, cname, asm3.utils.nulltostr(f.TOOLTIP), asm3.i18n._("No", l), asm3.i18n._("Yes", l)))
+                ( fid, cname, asm3.utils.iif(required != "", "required", ""), asm3.utils.nulltostr(f.TOOLTIP), asm3.i18n._("No", l), asm3.i18n._("Yes", l)))
         elif f.FIELDTYPE == FIELDTYPE_CHECKBOX:
             h.append('<input class="asm-onlineform-check" type="checkbox" id="%s" name="%s" %s /> ' \
                 '<label class="asm-onlineform-checkboxlabel" for="%s">%s</label>' % \

--- a/src/static/js/onlineform_extra.js
+++ b/src/static/js/onlineform_extra.js
@@ -193,6 +193,22 @@ $(document).ready(function() {
         return rv;
     };
 
+    const validate_yesno = function() {
+        let rv = true;
+        $(".asm-onlineform-yesno").each(function() {
+            if ($(this).attr("data-required")) {
+                let v = $(this).find(":selected").text();
+                if (!v) {
+                    alert("You must choose yes or no.");
+                    rv = false;
+                    $(this).focus();
+                    return false;
+                }
+            }
+        });
+        return rv;
+    };
+
     // Validate HTML5 required input fields 
     // (only does anything for browsers that don't support html5 required)
     const validate_required = function() {
@@ -393,6 +409,7 @@ $(document).ready(function() {
         if (!validate_email()) { enable(); return false; }
         if (!validate_required()) { enable(); return false; }
         if (!validate_images()) { enable(); return false; }
+        if (!validate_yesno()) { enable(); return false; }
         if (html5_required && !$("form")[0].checkValidity()) { 
             enable(); // the default behaviour highlights the required fields so we need it to happen
         }


### PR DESCRIPTION
When validating the form, check that Yes/No dropdowns marked as mandatory have either Yes or No selected and are not blank. The options available are as such for these type of fields.

![image](https://user-images.githubusercontent.com/1868836/124701120-9d082100-deb3-11eb-810b-3416045004ce.png)

With the changes, validation failure looks like below with the "blank" option selected.

![image](https://user-images.githubusercontent.com/1868836/124701173-b9a45900-deb3-11eb-9c59-35e9e01c6ab2.png)


Validation does not fail if yes or no is selected
