### PR TITLE
Hide clinic and boarding calendar views when remove options are enabled

### DIFF
--- a/src/static/js/calendarview.js
+++ b/src/static/js/calendarview.js
@@ -27,9 +27,7 @@ $(function() {
 
         render: function() {
             const chk = function(id, data, icon, label, tag="") {
-                if (tag) {
-                    tag = " " + tag;
-                }
+                if (tag) {tag = " " + tag;}
                 return '<span class="asm-calendar-legend' + tag + '">' + 
                     html.icon(icon) + 
                     '<input id="' + id + '" data="' + data + '" type="checkbox" class="asm-checkbox" /> ' +


### PR DESCRIPTION
As title suggests, the calendar options for boarding and clinic should be hidden when the remove options are enabled but currently remain visible.