### PR TITLE
maint_find_replace: Screen to fix typos in manufacturer, city and state

### DIFF
--- a/src/asm3/medical.py
+++ b/src/asm3/medical.py
@@ -634,12 +634,9 @@ def get_vaccinations_expiring_two_dates(dbo: Database, start: Database, end: Dat
         "AND a.DeceasedDate Is Null %s %s " \
         "ORDER BY av.DateExpires, a.AnimalName" % (shelterfilter, locationfilter), (start, end))
 
-def get_vacc_manufacturers(dbo: Database, includeblank=False) -> List[str]:
+def get_vacc_manufacturers(dbo: Database) -> List[str]:
     
-    if includeblank:
-        rows = dbo.query("SELECT DISTINCT Manufacturer FROM animalvaccination WHERE Manufacturer Is Not Null ORDER BY Manufacturer")
-    else:
-        rows = dbo.query("SELECT DISTINCT Manufacturer FROM animalvaccination WHERE Manufacturer Is Not Null AND Manufacturer <> '' ORDER BY Manufacturer")
+    rows = dbo.query("SELECT DISTINCT Manufacturer FROM animalvaccination WHERE Manufacturer Is Not Null AND Manufacturer <> '' ORDER BY Manufacturer")
     mf = []
     for r in rows:
         mf.append(r.MANUFACTURER)
@@ -860,13 +857,13 @@ def complete_test(dbo: Database, username: str, testid: int, newdate: datetime, 
     dbo.update("animaltest", testid, v, username)
     update_animal_tests(dbo, username, testid)
 
-def replace_manufacturers(dbo: Database, username: str, post: PostedData) -> None:
+def replace_manufacturers(dbo: Database, username: str, find: str, replace: str) -> None:
     """
-    Replaces the manufacturer in all vaccination records from posted form data
+    Replaces the manufacturer in all vaccination records
     """
     
-    return dbo.update("animalvaccination", "Manufacturer = '%s'" % post["manufacturerfind"], {
-        "Manufacturer": post["manufacturerreplace"]
+    return dbo.update("animalvaccination", "Manufacturer = %s" % dbo.sql_value(find), {
+        "Manufacturer": replace
     }, username)
 
 def reschedule_test(dbo: Database, username: str, testid: int, newdate: datetime, comments: str) -> None:

--- a/src/asm3/person.py
+++ b/src/asm3/person.py
@@ -254,11 +254,14 @@ def get_staff_volunteers(dbo: Database, siteid: int = 0) -> Results:
     if siteid is not None and siteid != 0: sitefilter = "AND o.SiteID = %s" % siteid
     return dbo.query(get_person_query(dbo) + " WHERE o.IsStaff = 1 OR o.IsVolunteer = 1 %s ORDER BY o.IsStaff DESC, o.OwnerSurname, o.OwnerForeNames" % sitefilter)
 
-def get_towns(dbo: Database) -> List[str]:
+def get_towns(dbo: Database, excludeblanks: bool = False) -> List[str]:
     """
     Returns a list of all towns
     """
-    rows = dbo.query("SELECT DISTINCT OwnerTown FROM owner ORDER BY OwnerTown")
+    if excludeblanks:
+        rows = dbo.query("SELECT DISTINCT OwnerTown FROM owner WHERE OwnerTown <> '' ORDER BY OwnerTown")
+    else:
+        rows = dbo.query("SELECT DISTINCT OwnerTown FROM owner ORDER BY OwnerTown")
     if rows is None: return []
     towns = []
     for r in rows:
@@ -276,11 +279,14 @@ def get_town_to_county(dbo: Database) -> List[str]:
         tc[r.OWNERTOWN] = r.OWNERCOUNTY
     return tc
 
-def get_counties(dbo: Database) -> List[str]:
+def get_counties(dbo: Database, excludeblanks: bool = False) -> List[str]:
     """
     Returns a list of counties
     """
-    rows = dbo.query("SELECT DISTINCT OwnerCounty FROM owner")
+    if excludeblanks:
+        rows = dbo.query("SELECT DISTINCT OwnerCounty FROM owner WHERE OwnerCounty <> '' ORDER BY OwnerCounty")
+    else:
+        rows = dbo.query("SELECT DISTINCT OwnerCounty FROM owner ORDER BY OwnerCounty")
     if rows is None: return []
     counties = []
     for r in rows:
@@ -2193,22 +2199,22 @@ def remove_people_only_cancelled_reserve(dbo: Database, years: int = None, usern
     asm3.al.debug("removed %d people with only cancelled reservations (remove after %s years)" % (len(people), years), "people.remove_people_only_cancelled_reserve", dbo)
     return "OK %s" % len(people)
 
-def replace_cities(dbo: Database, username: str, post: PostedData) -> None:
+def replace_cities(dbo: Database, username: str, find: str, replace: str) -> None:
     """
-    Replaces the town/city in all person records from posted form data
+    Replaces the town/city in all person records
     """
     
-    return dbo.update("owner", "OwnerTown = '%s'" % post["cityfind"], {
-        "OwnerTown": post["cityreplace"]
+    return dbo.update("owner", "OwnerTown = %s" % dbo.sql_value(find), {
+        "OwnerTown": replace
     }, username)
 
-def replace_states(dbo: Database, username: str, post: PostedData) -> None:
+def replace_states(dbo: Database, username: str, find: str, replace: str) -> None:
     """
-    Replaces the county/state in all person records from posted form data
+    Replaces the county/state in all person records
     """
     
-    return dbo.update("owner", "OwnerCounty = '%s'" % post["statefind"], {
-        "OwnerCounty": post["statereplace"]
+    return dbo.update("owner", "OwnerCounty = %s" % dbo.sql_value(find), {
+        "OwnerCounty": replace
     }, username)
 
 def update_anonymise_personal_data(dbo: Database, years: int = None, username: str = "system") -> str:

--- a/src/main.py
+++ b/src/main.py
@@ -5244,20 +5244,20 @@ class maint_find_replace(JSONEndpoint):
     def controller(self, o):
         dbo = o.dbo
         return {
-            "manufacturers": asm3.medical.get_vacc_manufacturers(dbo, includeblank=True),
-            "towns": asm3.person.get_towns(dbo),
-            "counties": asm3.person.get_counties(dbo),
+            "manufacturers": asm3.medical.get_vacc_manufacturers(dbo),
+            "towns": asm3.person.get_towns(dbo, excludeblanks=True),
+            "counties": asm3.person.get_counties(dbo, excludeblanks=True),
             "towncounties": asm3.person.get_town_to_county(dbo)
         }
     
     def post_replacemanufacturers(self, o):
-        return str(asm3.medical.replace_manufacturers(o.dbo, o.user, o.post))
+        return str(asm3.medical.replace_manufacturers(o.dbo, o.user, o.post["manufacturerfind"], o.post["manufacturerreplace"]))
 
     def post_replacecities(self, o):
-        return str(asm3.person.replace_cities(o.dbo, o.user, o.post))
+        return str(asm3.person.replace_cities(o.dbo, o.user, o.post["cityfind"], o.post["cityreplace"]))
     
     def post_replacestates(self, o):
-        return str(asm3.person.replace_states(o.dbo, o.user, o.post))
+        return str(asm3.person.replace_states(o.dbo, o.user, o.post["statefind"], o.post["statereplace"]))
 
 class maint_latency(JSONEndpoint):
     url = "maint_latency"

--- a/src/static/js/common_widgets.js
+++ b/src/static/js/common_widgets.js
@@ -867,6 +867,18 @@ $.fn.select = asm_widget({
         }
     },
 
+    /** Returns true if an option provided value exists, otherwise returns false */
+    hasOption: function(t, value) {
+        let result = false;
+        $.each(t.find("option"), function(i, v) {
+            if ($(v).val() == value) {
+                result = true;
+                return;
+            }
+        });
+        return result;
+    },
+
     /** Return the label for the selected option value */
     label: function(t) {
         return t.find("option:selected").html();

--- a/src/static/js/maint_find_replace.js
+++ b/src/static/js/maint_find_replace.js
@@ -9,55 +9,20 @@ $(function() {
         render: function() {
             let s = [
                 html.content_header(_("Find/replace")),
-                '<table id="findreplacetable">',
-                '<tbody>',
-                '<tr><td>' + _("Vaccine manufacturer") + '</td><td>',
                 tableform.fields_render([
-                    { post_field: "manufacturerfind", type: "select", justwidget: true,
-                        options: controller.manufacturers
-                    }
-                ]),
-                '</td><td>' + _("replace with") + '</td>',
-                '<td>',
-                tableform.fields_render([
-                    { post_field: "manufacturerreplace", type: "autotext", justwidget: true,
-                        options: controller.manufacturers
-                    }
-                ]),
-                '</td>',
-                '<td><button id="replacemanufacturers">' + _("Go") + '</button></td></tr>',
-                '<tr><td>' + _("City") + '</td><td>',
-                tableform.fields_render([
-                    { post_field: "cityfind", type: "select", justwidget: true,
-                        options: controller.towns
-                    }
-                ]),
-                '</td><td>' + _("replace with") + '</td>',
-                '<td>',
-                tableform.fields_render([
-                    { post_field: "cityreplace", type: "autotext", justwidget: true,
-                        options: controller.towns
-                    }
-                ]),
-                '</td>',
-                '<td><button id="replacecities">' + _("Go") + '</button></td></tr>',
-                '<tr><td>' + _("State") + '</td><td>',
-                tableform.fields_render([
-                    { post_field: "statefind", type: "select", justwidget: true,
-                        options: controller.counties
-                    }
-                ]),
-                '</td><td>' + _("replace with") + '</td>',
-                '<td>',
-                tableform.fields_render([
-                    { post_field: "statereplace", type: "autotext", justwidget: true,
-                        options: controller.counties
-                    }
-                ]),
-                '</td>',
-                '<td><button id="replacestates">' + _("Go") + '</button></td></tr>',
-                '</tbody>',
-                '</table>',
+                    { type: "raw", markup: '<h3>' + _("Vaccine manufacturer") + '</h3>' },
+                    { post_field: "manufacturerfind", label: _("Find"), type: "select", options: controller.manufacturers },
+                    { post_field: "manufacturerreplace", label: _("Replace with"), type: "autotext", options: controller.manufacturers },
+                    { type: "raw", markup: '<button class="replacebutton" id="replacemanufacturers">' + _("Go") + '</button>' },
+                    { type: "raw", markup: '<h3>' + _("Cities") + '</h3>' },
+                    { post_field: "cityfind", label: _("Find"), type: "select", options: controller.towns },
+                    { post_field: "cityreplace", label: _("Replace with"), type: "autotext", options: controller.towns },
+                    { type: "raw", markup: '<button class="replacebutton" id="replacemanufacturers">' + _("Go") + '</button>' },
+                    { type: "raw", markup: '<h3>' + _("States") + '</h3>' },
+                    { post_field: "statefind", label: _("Find"), type: "select", options: controller.counties },
+                    { post_field: "statereplace", label: _("Replace with"), type: "autotext", options: controller.counties },
+                    { type: "raw", markup: '<button class="replacebutton" id="replacemanufacturers">' + _("Go") + '</button>' },
+                ], { full_width: false }),
                 html.content_footer()
             ].join("\n");
 
@@ -71,14 +36,7 @@ $(function() {
                 let formdata = "mode=replacemanufacturers&" + $("#manufacturerfind, #manufacturerreplace").toPOST();
                 let result = await common.ajax_post("maint_find_replace", formdata);
                 $("#manufacturerfind option:selected").remove();
-                let termpresent = false;
-                $.each($("#manufacturerfind option"), function(i, v) {
-                    if ( $(v).val() == $("#manufacturerreplace").val() ) {
-                        termpresent = true;
-                        return;
-                    }
-                });
-                if (!termpresent) {
+                if ( !$("#manufacturerfind").select("hasOption", $("#manufacturerreplace").val()) ) {
                     $("#manufacturerfind").append('<option>' + $("#manufacturerreplace").val() + '</option>');
                 }
                 header.show_info(_("{0} vaccination record(s) affected").replace("{0}", result));
@@ -89,14 +47,7 @@ $(function() {
                 let formdata = "mode=replacecities&" + $("#cityfind, #cityreplace").toPOST();
                 let result = await common.ajax_post("maint_find_replace", formdata);
                 $("#cityfind option:selected").remove();
-                let termpresent = false;
-                $.each($("#cityfind option"), function(i, v) {
-                    if ( $(v).val() == $("#cityreplace").val() ) {
-                        termpresent = true;
-                        return;
-                    }
-                });
-                if (!termpresent) {
+                if ( !$("#cityfind").select("hasOption", $("#cityreplace").val()) ) {
                     $("#cityfind").append('<option>' + $("#cityreplace").val() + '</option>');
                 }
                 header.show_info(_("{0} person record(s) affected").replace("{0}", result));
@@ -107,14 +58,7 @@ $(function() {
                 let formdata = "mode=replacestates&" + $("#statefind, #statereplace").toPOST();
                 let result = await common.ajax_post("maint_find_replace", formdata);
                 $("#statefind option:selected").remove();
-                let termpresent = false;
-                $.each($("#statefind option"), function(i, v) {
-                    if ( $(v).val() == $("#statereplace").val() ) {
-                        termpresent = true;
-                        return;
-                    }
-                });
-                if (!termpresent) {
+                if ( !$("#statefind").select("hasOption", $("#statereplace").val()) ) {
                     $("#statefind").append('<option>' + $("#statereplace").val() + '</option>');
                 }
                 header.show_info(_("{0} person record(s) affected").replace("{0}", result));
@@ -123,7 +67,7 @@ $(function() {
         },
 
         sync: function() {
-            $("#findreplacetable button").button();
+            $(".replacebutton").button();
         },
 
         name: "maint_find_replace",

--- a/src/static/js/person.js
+++ b/src/static/js/person.js
@@ -73,7 +73,7 @@ $(function() {
                     { post_field: "county", json_field: "OWNERCOUNTY", type: "select", label: _("State"), rowclasses: "towncounty", 
                         options: html.states_us_options(config.str("OrganisationCounty")) },
                     { post_field: "county", json_field: "OWNERCOUNTY", type: "autotext", label: _("State"), rowclasses: "towncounty", 
-                        minlength: 3, options: controller.counties }),
+                        minlength: 2, options: controller.counties }),
                 { post_field: "postcode", json_field: "OWNERPOSTCODE", type: "text", label: _("Zipcode") },
                 { post_field: "country", json_field: "OWNERCOUNTRY", type: "text", label: _("Country") }, 
                 { post_field: "latlong", json_field: "LATLONG", type: "latlong", label: _("Latitude/Longitude"), 


### PR DESCRIPTION
There are a few places where we use autocomplete fields and the source of their data is previous values entered into that field.

What invariably happens is that users enter garbage full of typos instead of picking the correct value from the autocomplete when they see it (or typing it correctly in the first place).

The worst offending fields for this are vaccination manufacturer, person city and person state.

Create a new hidden screen (ie. no menu entry) called maint_find_replace. This screen should have a row for each of these fields.:

                     FIND          -> REPLACE WITH
vacc manufacturer [find]           ->[          ]  [go]
person city [find]                ->[          ]  [go]
person state [find]                ->[          ]  [go]

The find and replace columns show a select/dropdown that contains the current options for that field. Replace has the same list of options, allowing you to swap one typo value for another.

The go button does a post to the backend to do the actual replace. A bit of js after the post should remove the selected option in the find dropdown from the list in both find and replace so that a page transition isn't needed to refresh the dropdowns.