### PR TITLE
MedicalType[Type]Name wordprocessor token

### DIFF
--- a/src/asm3/medical.py
+++ b/src/asm3/medical.py
@@ -337,11 +337,11 @@ def get_batch_for_vaccination_types(dbo: Database) -> Results:
 def get_medical_types_animal(dbo: Database, animalid: int) -> Results:
     """
     Returns a recordset of medicaltypes for an animal:
-    MEDICALTYPE, DATEREQUIRED, LASTGIVEN
+    MEDICALTYPE, TREATMENTNAME, DATEREQUIRED, LASTGIVEN
     """
     sql = "SELECT mt.MedicalTypeName, " \
         "(" \
-            "SELECT DateRequired " \
+            f"SELECT {dbo.sql_concat(['DateRequired', '"$$"', 'TreatmentName'])} " \
             "FROM animalmedicaltreatment " \
             "INNER JOIN animalmedical ON animalmedicaltreatment.AnimalMedicalID = animalmedical.ID " \
             "INNER JOIN lksmedicaltype ON animalmedical.MedicalTypeID  = lksmedicaltype.ID " \
@@ -349,7 +349,7 @@ def get_medical_types_animal(dbo: Database, animalid: int) -> Results:
             "ORDER BY DateRequired desc LIMIT 1" \
         ") AS DateRequired," \
         "(" \
-            "SELECT DateGiven " \
+            f"SELECT {dbo.sql_concat(['DateGiven', '"$$"', 'TreatmentName'])} " \
             "FROM animalmedicaltreatment " \
             "INNER JOIN animalmedical ON animalmedicaltreatment.AnimalMedicalID = animalmedical.ID " \
             "INNER JOIN lksmedicaltype ON animalmedical.MedicalTypeID  = lksmedicaltype.ID " \

--- a/src/asm3/medical.py
+++ b/src/asm3/medical.py
@@ -346,7 +346,8 @@ def get_medical_types_animal(dbo: Database, animalid: int) -> Results:
             "INNER JOIN animalmedical ON animalmedicaltreatment.AnimalMedicalID = animalmedical.ID " \
             "INNER JOIN lksmedicaltype ON animalmedical.MedicalTypeID  = lksmedicaltype.ID " \
             "WHERE animalmedicaltreatment.AnimalID = ? AND animalmedicaltreatment.DateRequired >= ? AND animalmedical.MedicalTypeID = mt.ID " \
-            "ORDER BY DateRequired desc LIMIT 1" \
+            "AND animalmedicaltreatment.DateGiven IS NULL " \
+            "ORDER BY DateRequired LIMIT 1" \
         ") AS DateRequired, " \
         "(" \
             "SELECT TreatmentName " \
@@ -354,7 +355,8 @@ def get_medical_types_animal(dbo: Database, animalid: int) -> Results:
             "INNER JOIN animalmedical ON animalmedicaltreatment.AnimalMedicalID = animalmedical.ID " \
             "INNER JOIN lksmedicaltype ON animalmedical.MedicalTypeID  = lksmedicaltype.ID " \
             "WHERE animalmedicaltreatment.AnimalID = ? AND animalmedicaltreatment.DateRequired >= ? AND animalmedical.MedicalTypeID = mt.ID " \
-            "ORDER BY DateRequired desc LIMIT 1" \
+            "AND animalmedicaltreatment.DateGiven IS NULL " \
+            "ORDER BY DateRequired LIMIT 1" \
         ") AS DateRequiredTreatmentName, " \
         "(" \
             "SELECT DateGiven " \

--- a/src/asm3/medical.py
+++ b/src/asm3/medical.py
@@ -337,27 +337,43 @@ def get_batch_for_vaccination_types(dbo: Database) -> Results:
 def get_medical_types_animal(dbo: Database, animalid: int) -> Results:
     """
     Returns a recordset of medicaltypes for an animal:
-    MEDICALTYPE, DATEREQUIRED$$TREATMENTNAME, LASTGIVEN$$TREATMENTNAME
+    MEDICALTYPE, DATEREQUIRED, DATEREQUIREDTREATMENTNAME, LASTGIVEN, LASTGIVENTREATMENTNAME
     """
     sql = "SELECT mt.MedicalTypeName, " \
         "(" \
-            f"SELECT {dbo.sql_concat(['DateRequired', '"$$"', 'TreatmentName'])} " \
+            "SELECT DateRequired " \
             "FROM animalmedicaltreatment " \
             "INNER JOIN animalmedical ON animalmedicaltreatment.AnimalMedicalID = animalmedical.ID " \
             "INNER JOIN lksmedicaltype ON animalmedical.MedicalTypeID  = lksmedicaltype.ID " \
             "WHERE animalmedicaltreatment.AnimalID = ? AND animalmedicaltreatment.DateRequired >= ? AND animalmedical.MedicalTypeID = mt.ID " \
             "ORDER BY DateRequired desc LIMIT 1" \
-        ") AS DateRequired," \
+        ") AS DateRequired, " \
         "(" \
-            f"SELECT {dbo.sql_concat(['DateGiven', '"$$"', 'TreatmentName'])} " \
+            "SELECT TreatmentName " \
+            "FROM animalmedicaltreatment " \
+            "INNER JOIN animalmedical ON animalmedicaltreatment.AnimalMedicalID = animalmedical.ID " \
+            "INNER JOIN lksmedicaltype ON animalmedical.MedicalTypeID  = lksmedicaltype.ID " \
+            "WHERE animalmedicaltreatment.AnimalID = ? AND animalmedicaltreatment.DateRequired >= ? AND animalmedical.MedicalTypeID = mt.ID " \
+            "ORDER BY DateRequired desc LIMIT 1" \
+        ") AS DateRequiredTreatmentName, " \
+        "(" \
+            "SELECT DateGiven " \
             "FROM animalmedicaltreatment " \
             "INNER JOIN animalmedical ON animalmedicaltreatment.AnimalMedicalID = animalmedical.ID " \
             "INNER JOIN lksmedicaltype ON animalmedical.MedicalTypeID  = lksmedicaltype.ID " \
             "WHERE animalmedicaltreatment.AnimalID = ? AND animalmedical.MedicalTypeID = mt.ID AND DateGiven IS NOT NULL " \
             "ORDER BY DateGiven desc LIMIT 1" \
-        ") AS DateGiven " \
+        ") AS DateGiven, " \
+        "(" \
+            "SELECT TreatmentName " \
+            "FROM animalmedicaltreatment " \
+            "INNER JOIN animalmedical ON animalmedicaltreatment.AnimalMedicalID = animalmedical.ID " \
+            "INNER JOIN lksmedicaltype ON animalmedical.MedicalTypeID  = lksmedicaltype.ID " \
+            "WHERE animalmedicaltreatment.AnimalID = ? AND animalmedical.MedicalTypeID = mt.ID AND DateGiven IS NOT NULL " \
+            "ORDER BY DateGiven desc LIMIT 1" \
+        ") AS DateGivenTreatmentName " \
         "FROM lksmedicaltype mt"
-    return dbo.query(sql, [animalid, dbo.today(), animalid ])
+    return dbo.query(sql, [animalid, dbo.today(), animalid, dbo.today(), animalid, animalid ])
 
 def get_regimens(dbo: Database, animalid: int, onlycomplete: bool = False, onlyactive: bool = False, sort: int = ASCENDING_REQUIRED) -> Results:
     """

--- a/src/asm3/medical.py
+++ b/src/asm3/medical.py
@@ -337,7 +337,7 @@ def get_batch_for_vaccination_types(dbo: Database) -> Results:
 def get_medical_types_animal(dbo: Database, animalid: int) -> Results:
     """
     Returns a recordset of medicaltypes for an animal:
-    MEDICALTYPE, TREATMENTNAME, DATEREQUIRED, LASTGIVEN
+    MEDICALTYPE, DATEREQUIRED$$TREATMENTNAME, LASTGIVEN$$TREATMENTNAME
     """
     sql = "SELECT mt.MedicalTypeName, " \
         "(" \

--- a/src/asm3/wordprocessor.py
+++ b/src/asm3/wordprocessor.py
@@ -21,7 +21,7 @@ import asm3.users
 import asm3.utils
 import asm3.waitinglist
 
-from asm3.i18n import _, date_diff_days, format_currency, format_currency_no_symbol, format_diff, format_diff_single, format_time, now, parse_date, python2display, python2displaytime, yes_no
+from asm3.i18n import _, date_diff_days, format_currency, format_currency_no_symbol, format_diff, format_diff_single, format_time, now, python2display, python2displaytime, yes_no
 from asm3.sitedefs import SERVICE_URL
 from asm3.typehints import bytes_or_str, Database, Dict, List, ResultRow, Results, Tags, Tuple
 
@@ -859,22 +859,10 @@ def animal_tags(dbo: Database, a: ResultRow, includeAdditional=True, includeCost
         for mt in medicaltypes:
             tagname = "MEDICALTYPE" + mt["MEDICALTYPENAME"].replace(" ", "").replace("/", "").upper()
             tags[tagname] = mt["MEDICALTYPENAME"].upper()
-            if mt["DATEGIVEN"]:
-                dategivenstr = mt["DATEGIVEN"].split("$$")[0]
-                dategiven = parse_date("%Y-%m-%d %H:%M:%S", dategivenstr)
-                tags[tagname + "GIVEN"] = python2display(l, dategiven)
-                tags[tagname + "GIVENNAME"] = mt["DATEGIVEN"].split("$$")[1]
-            else:
-                tags[tagname + "GIVEN"] = ""
-                tags[tagname + "GIVENNAME"] = ""
-            if mt["DATEREQUIRED"]:
-                dateduestr = mt["DATEREQUIRED"].split("$$")[0]
-                datedue = parse_date("%Y-%m-%d %H:%M:%S", dateduestr)
-                tags[tagname + "DUE"] = python2display(l, datedue)
-                tags[tagname + "DUENAME"] = mt["DATEREQUIRED"].split("$$")[1]
-            else:
-                tags[tagname + "DUE"] = ""
-                tags[tagname + "DUENAME"] = ""
+            tags[tagname + "GIVEN"] = python2display(l, mt["DATEGIVEN"])
+            tags[tagname + "GIVENNAME"] = mt["DATEGIVENTREATMENTNAME"]
+            tags[tagname + "DUE"] = python2display(l, mt["DATEREQUIRED"])
+            tags[tagname + "DUENAME"] = mt["DATEREQUIREDTREATMENTNAME"]
         
         # Conditions
         d = {

--- a/src/asm3/wordprocessor.py
+++ b/src/asm3/wordprocessor.py
@@ -21,7 +21,7 @@ import asm3.users
 import asm3.utils
 import asm3.waitinglist
 
-from asm3.i18n import _, date_diff_days, format_currency, format_currency_no_symbol, format_diff, format_diff_single, format_time, now, python2display, python2displaytime, yes_no
+from asm3.i18n import _, date_diff_days, format_currency, format_currency_no_symbol, format_diff, format_diff_single, format_time, now, parse_date, python2display, python2displaytime, yes_no
 from asm3.sitedefs import SERVICE_URL
 from asm3.typehints import bytes_or_str, Database, Dict, List, ResultRow, Results, Tags, Tuple
 
@@ -852,15 +852,29 @@ def animal_tags(dbo: Database, a: ResultRow, includeAdditional=True, includeCost
         medicaltypes = asm3.medical.get_medical_types_animal(dbo, a["ID"])
         tags["ANIMALMEDICALTYPES"] = html_table(l, medicaltypes, (
             ( "MEDICALTYPENAME", _("Medical Type", l) ),
-            ( "DATEREQUIRED", _("Next due", l) ),
+            ( "DATEREQUIRED", _("Next Due", l) ),
             ( "DATEGIVEN", _("Last Given", l) )
         ))
 
         for mt in medicaltypes:
             tagname = "MEDICALTYPE" + mt["MEDICALTYPENAME"].replace(" ", "").replace("/", "").upper()
             tags[tagname] = mt["MEDICALTYPENAME"].upper()
-            tags[tagname + "GIVEN"] = python2display(l, mt["DATEGIVEN"])
-            tags[tagname + "DUE"] = python2display(l, mt["DATEREQUIRED"])
+            if mt["DATEGIVEN"]:
+                dategivenstr = mt["DATEGIVEN"].split("$$")[0]
+                dategiven = parse_date("%Y-%m-%d %H:%M:%S", dategivenstr)
+                tags[tagname + "GIVEN"] = python2display(l, dategiven)
+                tags[tagname + "GIVENNAME"] = mt["DATEGIVEN"].split("$$")[1]
+            else:
+                tags[tagname + "GIVEN"] = ""
+                tags[tagname + "GIVENNAME"] = ""
+            if mt["DATEREQUIRED"]:
+                dateduestr = mt["DATEREQUIRED"].split("$$")[0]
+                datedue = parse_date("%Y-%m-%d %H:%M:%S", dateduestr)
+                tags[tagname + "DUE"] = python2display(l, datedue)
+                tags[tagname + "DUENAME"] = mt["DATEREQUIRED"].split("$$")[1]
+            else:
+                tags[tagname + "DUE"] = ""
+                tags[tagname + "DUENAME"] = ""
         
         # Conditions
         d = {


### PR DESCRIPTION
We currently only have two tokens for MedicalType[Type]Given and Due. A customer asked if we could have MedicalType[Type]Name as well so that their document can indicate the specific treatment administered for that medical type.

Should be fairly straightforward, update medical.py to add another subquery to get_medical_types_animal to retrieve the TreatmentName column from animalmedical, and have the code in wordprocessor.py use it.