### PR TITLE
Toolbar buttons stay enabled after a list item has been changed

### DIFF
--- a/src/static/js/common_tableform.js
+++ b/src/static/js/common_tableform.js
@@ -365,6 +365,9 @@ const tableform = {
         this.table_bind_widgets(table);
         $("#tableform").trigger("update");
         this.table_apply_sort(table);
+        if (table.buttons) {
+            tableform.table_update_buttons(table, table.buttons);
+        }
     },
 
     /**
@@ -477,6 +480,7 @@ const tableform = {
         // Watch for number of selected checkboxes changing and update 
         // the enable/disabled state of buttons
         if (buttons) {
+            table.buttons = buttons;
             $("#tableform").on("click", "input[type='checkbox']", function() {
                 tableform.table_update_buttons(table, buttons);
             });


### PR DESCRIPTION
Pick any tableform screen, tick a checkbox to select a record and the toolbar buttons enable. If you then click an item and make a change to it, the boxes are unselected (because table_update() will have run) but the toolbar buttons stay enabled.

The fix is to make tableform.table_update accept the buttons reference as a second parameter. Then, if buttons have been supplied to the table_update function, call tableform.table_update_buttons() to reset their state.

Then, all tableform screens that call tableform.table_update() should supply table and buttons if available.